### PR TITLE
feat: only accept payload as `string`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ const { sign, verify } = require("@octokit/webhooks-methods");
 </table>
 
 ```js
-await sign("mysecret", eventPayload);
+await sign("mysecret", eventPayloadString);
 // resolves with a string like "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3"
 
-await sign({ secret: "mysecret", algorithm: "sha1" }, eventPayload);
+await sign({ secret: "mysecret", algorithm: "sha1" }, eventPayloadString);
 // resolves with a string like "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8"
 
-await verify("mysecret", eventPayload, "sha256=486d27...");
+await verify("mysecret", eventPayloadString, "sha256=486d27...");
 // resolves with true or false
 ```
 
@@ -77,8 +77,8 @@ await verify("mysecret", eventPayload, "sha256=486d27...");
 ### `sign()`
 
 ```js
-await sign(secret, eventPayload);
-await sign({ secret, algorithm }, eventPayload);
+await sign(secret, eventPayloadString);
+await sign({ secret, algorithm }, eventPayloadString);
 ```
 
 <table width="100%">
@@ -114,15 +114,17 @@ Learn more at [Validating payloads from GitHub](https://docs.github.com/en/devel
   <tr>
     <td>
       <code>
-        eventPayload
+        eventPayloadString
       </code>
       <em>
-        (Object)
+        (String)
       </em>
     </td>
     <td>
       <strong>Required.</strong>
-      Webhook request payload as received from GitHub
+      Webhook request payload as received from GitHub.<br>
+      <br>
+      If you have only access to an already parsed object, stringify it with <code>JSON.stringify(payload, null, 2) + '\n'</code>
     </td>
   </tr>
 </table>
@@ -132,7 +134,7 @@ Resolves with a `signature` string. Throws an error if an argument is missing.
 ### `verify()`
 
 ```js
-await verify(secret, eventPayload, signature);
+await verify(secret, eventPayloadString, signature);
 ```
 
 <table width="100%">
@@ -151,15 +153,17 @@ await verify(secret, eventPayload, signature);
   <tr>
     <td>
       <code>
-        eventPayload
+        eventPayloadString
       </code>
       <em>
-        (Object)
+        (String)
       </em>
     </td>
     <td>
       <strong>Required.</strong>
-      Webhook request payload as received from GitHub
+      Webhook request payload as received from GitHub.<br>
+      <br>
+      If you have only access to an already parsed object, stringify it with <code>JSON.stringify(payload, null, 2) + '\n'</code>
     </td>
   </tr>
   <tr>

--- a/src/node/sign.ts
+++ b/src/node/sign.ts
@@ -13,7 +13,7 @@ type SignOptions = {
 
 export async function sign(
   options: SignOptions | string,
-  payload: string | object
+  payload: string
 ): Promise<string> {
   const { secret, algorithm } =
     typeof options === "object"
@@ -35,17 +35,9 @@ export async function sign(
     );
   }
 
-  payload =
-    typeof payload === "string" ? payload : toNormalizedJsonString(payload);
   return `${algorithm}=${createHmac(algorithm, secret)
     .update(payload)
     .digest("hex")}`;
-}
-
-function toNormalizedJsonString(payload: object) {
-  return JSON.stringify(payload).replace(/[^\\]\\u[\da-f]{4}/g, (s) => {
-    return s.substr(0, 3) + s.substr(3).toUpperCase();
-  });
 }
 
 sign.VERSION = VERSION;

--- a/src/node/verify.ts
+++ b/src/node/verify.ts
@@ -10,7 +10,7 @@ const getAlgorithm = (signature: string) => {
 
 export async function verify(
   secret: string,
-  eventPayload: string | object,
+  eventPayload: string,
   signature: string
 ): Promise<boolean> {
   if (!secret || !eventPayload || !signature) {

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -44,44 +44,6 @@ describe("sign", () => {
     );
   });
 
-  describe("with eventPayload as object", () => {
-    describe("returns expected sha1 signature", () => {
-      test("sign(secret, eventPayload)", async () => {
-        const signature = await sign(secret, eventPayload);
-        expect(signature).toBe(
-          "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3"
-        );
-      });
-
-      test("sign({secret}, eventPayload)", async () => {
-        const signature = await sign({ secret }, eventPayload);
-        expect(signature).toBe(
-          "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3"
-        );
-      });
-
-      test("sign({secret, algorithm: 'sha1'}, eventPayload)", async () => {
-        const signature = await sign(
-          { secret, algorithm: "sha1" },
-          eventPayload
-        );
-        expect(signature).toBe("sha1=d03207e4b030cf234e3447bac4d93add4c6643d8");
-      });
-    });
-
-    describe("returns expected sha256 signature", () => {
-      test("sign({secret, algorithm}, eventPayload)", async () => {
-        const signature = await sign(
-          { secret, algorithm: "sha256" },
-          eventPayload
-        );
-        expect(signature).toBe(
-          "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3"
-        );
-      });
-    });
-  });
-
   describe("with eventPayload as string", () => {
     describe("returns expected sha1 signature", () => {
       test("sign(secret, eventPayload)", async () => {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -1,12 +1,18 @@
 import { verify } from "../src";
 
-const eventPayload = {
-  foo: "bar",
-};
+function toNormalizedJsonString(payload: object) {
+  // GitHub sends its JSON with an indentation of 2 spaces and a line break at the end
+  const payloadString = JSON.stringify(payload, null, 2) + "\n";
+  return payloadString.replace(/[^\\]\\u[\da-f]{4}/g, (s) => {
+    return s.substr(0, 3) + s.substr(3).toUpperCase();
+  });
+}
+
+const eventPayload = toNormalizedJsonString({ foo: "bar" });
 const secret = "mysecret";
-const signatureSHA1 = "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8";
+const signatureSHA1 = "sha1=640c0ea7402a3f74e1767338fa2dba243b1f2d9c";
 const signatureSHA256 =
-  "sha256=4864d2759938a15468b5df9ade20bf161da9b4f737ea61794142f3484236bda3";
+  "sha256=e3eccac34c43c7dc1cbb905488b1b81347fcc700a7b025697a9d07862256023f";
 
 describe("verify", () => {
   it("is a function", () => {
@@ -64,26 +70,26 @@ describe("verify", () => {
     // https://github.com/octokit/webhooks.js/issues/71
     const signatureMatchesLowerCaseSequence = await verify(
       "development",
-      {
+      toNormalizedJsonString({
         foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
-      },
-      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+      }),
+      "sha1=82a91c5aacc9cdc2eea893bc828bd03d218df79c"
     );
     expect(signatureMatchesLowerCaseSequence).toBe(true);
     const signatureMatchesUpperCaseSequence = await verify(
       "development",
-      {
+      toNormalizedJsonString({
         foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
-      },
-      "sha1=7316ec5e7866e42e4aba4af550d21a5f036f949d"
+      }),
+      "sha1=82a91c5aacc9cdc2eea893bc828bd03d218df79c"
     );
     expect(signatureMatchesUpperCaseSequence).toBe(true);
     const signatureMatchesEscapedSequence = await verify(
       "development",
-      {
+      toNormalizedJsonString({
         foo: "\\u001b",
-      },
-      "sha1=2c440a176f4cb84c8c921dfee882d594c2465097"
+      }),
+      "sha1=bdae4705bdd827d026bb227817ca025b5b3a6756"
     );
     expect(signatureMatchesEscapedSequence).toBe(true);
   });
@@ -111,26 +117,26 @@ describe("verify", () => {
     // https://github.com/octokit/webhooks.js/issues/71
     const signatureMatchesLowerCaseSequence = await verify(
       "development",
-      {
+      toNormalizedJsonString({
         foo: "Foo\n\u001b[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001b[0m\u001b[2K",
-      },
-      "sha256=afecc3caa27548bb90d51a50384cb2868b9a3327b4ad6a01c9bd4ed0f8b0b12c"
+      }),
+      "sha256=9dacf9003316b09be07df56d86a2d0d6872e42a1e6c72c3bad9ff915a7c5603e"
     );
     expect(signatureMatchesLowerCaseSequence).toBe(true);
     const signatureMatchesUpperCaseSequence = await verify(
       "development",
-      {
+      toNormalizedJsonString({
         foo: "Foo\n\u001B[34mbar: ♥♥♥♥♥♥♥♥\nthis-is-lost\u001B[0m\u001B[2K",
-      },
-      "sha256=afecc3caa27548bb90d51a50384cb2868b9a3327b4ad6a01c9bd4ed0f8b0b12c"
+      }),
+      "sha256=9dacf9003316b09be07df56d86a2d0d6872e42a1e6c72c3bad9ff915a7c5603e"
     );
     expect(signatureMatchesUpperCaseSequence).toBe(true);
     const signatureMatchesEscapedSequence = await verify(
       "development",
-      {
+      toNormalizedJsonString({
         foo: "\\u001b",
-      },
-      "sha256=6f8326efbacfbd04e870cea25b5652e635be8c9807f2fd5348ef60753c9e96ed"
+      }),
+      "sha256=87316067e2011fae39998b18c46a14d83b3e7c3ffdd88fb2ee5afb7d11288e60"
     );
     expect(signatureMatchesEscapedSequence).toBe(true);
   });


### PR DESCRIPTION
BREAKING CHANGE: `sign` or `verify` no longer accept an object for the event payload argument.

If you only have access to an already parsed object, stringify it with

```js
const eventPayloadString = JSON.stringify(eventPayload, null, 2) + "\n";
```
