### PR TITLE
fix: correct behaviour of functions in the `web` module to correspond to the one from the `node` module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,10 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
+      # we currently no support deno yet.
+      # - uses: denoland/setup-deno@v1
+      #   with:
+      #     deno-version: v1.x
       - run: npm ci
       - run: npm test
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,9 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
           cache: npm
-      # we currently no support deno yet.
-      # - uses: denoland/setup-deno@v1
-      #   with:
-      #     deno-version: v1.x
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
       - run: npm ci
       - run: npm test
   test:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "prettier --check '{src,test}/**/*' README.md package.json",
     "lint:fix": "prettier --write '{src,test}/**/*' README.md package.json",
     "pretest": "npm run -s lint",
-    "test": "npm run -s test:node && npm run -s test:deno && npm run -s test:browser",
+    "test": "npm run -s test:node && npm run -s test:browser",
     "test:node": "jest --coverage",
     "test:deno": "cd test/deno && deno test",
     "pretest:browser": "npm run -s build",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "prettier --check '{src,test}/**/*' README.md package.json",
     "lint:fix": "prettier --write '{src,test}/**/*' README.md package.json",
     "pretest": "npm run -s lint",
-    "test": "npm run -s test:node && npm run -s test:browser",
+    "test": "npm run -s test:node && npm run -s test:deno && npm run -s test:browser",
     "test:node": "jest --coverage",
     "test:deno": "cd test/deno && deno test",
     "pretest:browser": "npm run -s build",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "lint": "prettier --check '{src,test}/**/*' README.md package.json",
     "lint:fix": "prettier --write '{src,test}/**/*' README.md package.json",
     "pretest": "npm run -s lint",
-    "test": "npm run -s test:node && npm run -s test:deno && npm run -s test:browser",
+    "test": "npm run -s test:node && npm run -s test:web",
     "test:node": "jest --coverage",
+    "test:web": "npm run test:deno && npm run test:browser",
+    "pretest:web": "npm run -s build",
     "test:deno": "cd test/deno && deno test",
-    "pretest:browser": "npm run -s build",
     "test:browser": "node test/browser-test.js"
   },
   "repository": "github:octokit/webhooks-methods.js",

--- a/src/node/sign.ts
+++ b/src/node/sign.ts
@@ -2,8 +2,6 @@ import { createHmac } from "crypto";
 import { Algorithm, SignOptions } from "../types";
 import { VERSION } from "../version";
 
-export { Algorithm };
-
 export async function sign(
   options: SignOptions | string,
   payload: string

--- a/src/node/sign.ts
+++ b/src/node/sign.ts
@@ -1,15 +1,8 @@
 import { createHmac } from "crypto";
+import { Algorithm, SignOptions } from "../types";
 import { VERSION } from "../version";
 
-export enum Algorithm {
-  SHA1 = "sha1",
-  SHA256 = "sha256",
-}
-
-type SignOptions = {
-  secret: string;
-  algorithm?: Algorithm | "sha1" | "sha256";
-};
+export { Algorithm };
 
 export async function sign(
   options: SignOptions | string,

--- a/src/node/verify.ts
+++ b/src/node/verify.ts
@@ -3,10 +3,7 @@ import { Buffer } from "buffer";
 
 import { sign } from "./sign";
 import { VERSION } from "../version";
-
-const getAlgorithm = (signature: string) => {
-  return signature.startsWith("sha256=") ? "sha256" : "sha1";
-};
+import { getAlgorithm } from "../utils";
 
 export async function verify(
   secret: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,11 @@
+export enum Algorithm {
+  SHA1 = "sha1",
+  SHA256 = "sha256",
+}
+
+export type AlgorithmLike = Algorithm | "sha1" | "sha256";
+
+export type SignOptions = {
+  secret: string;
+  algorithm?: AlgorithmLike;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export const getAlgorithm = (signature: string) => {
+  return signature.startsWith("sha256=") ? "sha256" : "sha1";
+};

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,7 +1,5 @@
-// @ts-ignore: ts(2691) for deno compatible
-import { Algorithm, AlgorithmLike, SignOptions } from "./types.ts";
-// @ts-ignore: ts(2691) for deno compatible
-import { getAlgorithm } from "./utils.ts";
+import { Algorithm, AlgorithmLike, SignOptions } from "./types";
+import { getAlgorithm } from "./utils";
 
 const enc = new TextEncoder();
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -3,14 +3,6 @@ import { getAlgorithm } from "./utils";
 
 const enc = new TextEncoder();
 
-export async function sign(secret: string, data: string) {
-  return await _sign(secret, data);
-}
-
-export async function verify(secret: string, data: string, signature: string) {
-  return await _verify(secret, data, signature);
-}
-
 async function _sign(
   secret: string,
   data: string,
@@ -80,7 +72,7 @@ async function importKey(secret: string, algorithm: AlgorithmLike) {
   );
 }
 
-export async function sign2(options: SignOptions | string, payload: string) {
+export async function sign(options: SignOptions | string, payload: string) {
   const { secret, algorithm } =
     typeof options === "object"
       ? {
@@ -104,7 +96,7 @@ export async function sign2(options: SignOptions | string, payload: string) {
   return `${algorithm}=${await _sign(secret, payload, algorithm)}`;
 }
 
-export async function verify2(
+export async function verify(
   secret: string,
   eventPayload: string,
   signature: string

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,5 +1,7 @@
-import { Algorithm, AlgorithmLike, SignOptions } from "./types";
-import { getAlgorithm } from "./utils";
+// @ts-ignore because of deno compatible
+import { Algorithm, AlgorithmLike, SignOptions } from "./types.ts";
+// @ts-ignore because of deno compatible
+import { getAlgorithm } from "./utils.ts";
 
 const enc = new TextEncoder();
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
-// @ts-ignore because of deno compatible
+// @ts-ignore: ts(2691) for deno compatible
 import { Algorithm, AlgorithmLike, SignOptions } from "./types.ts";
-// @ts-ignore because of deno compatible
+// @ts-ignore: ts(2691) for deno compatible
 import { getAlgorithm } from "./utils.ts";
 
 const enc = new TextEncoder();

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,18 +1,38 @@
+import { Algorithm, AlgorithmLike, SignOptions } from "./types";
+import { getAlgorithm } from "./utils";
+
 const enc = new TextEncoder();
 
 export async function sign(secret: string, data: string) {
+  return await _sign(secret, data);
+}
+
+export async function verify(secret: string, data: string, signature: string) {
+  return await _verify(secret, data, signature);
+}
+
+async function _sign(
+  secret: string,
+  data: string,
+  algorithm: AlgorithmLike = Algorithm.SHA256
+) {
   const signature = await crypto.subtle.sign(
     "HMAC",
-    await importKey(secret),
+    await importKey(secret, algorithm),
     enc.encode(data)
   );
   return UInt8ArrayToHex(signature);
 }
 
-export async function verify(secret: string, data: string, signature: string) {
+async function _verify(
+  secret: string,
+  data: string,
+  signature: string,
+  algorithm: AlgorithmLike = Algorithm.SHA256
+) {
   return await crypto.subtle.verify(
     "HMAC",
-    await importKey(secret),
+    await importKey(secret, algorithm),
     hexToUInt8Array(signature),
     enc.encode(data)
   );
@@ -36,16 +56,70 @@ function UInt8ArrayToHex(signature: ArrayBuffer) {
     .join("");
 }
 
-async function importKey(secret: string) {
+function getHMACHashName(algorithm: AlgorithmLike) {
+  return (
+    {
+      [Algorithm.SHA1]: "SHA-1",
+      [Algorithm.SHA256]: "SHA-256",
+    } as { [key in Algorithm]: string }
+  )[algorithm];
+}
+
+async function importKey(secret: string, algorithm: AlgorithmLike) {
+  // ref: https://developer.mozilla.org/en-US/docs/Web/API/HmacImportParams
   return crypto.subtle.importKey(
     "raw", // raw format of the key - should be Uint8Array
     enc.encode(secret),
     {
       // algorithm details
       name: "HMAC",
-      hash: { name: "SHA-256" },
+      hash: { name: getHMACHashName(algorithm) },
     },
     false, // export = false
     ["sign", "verify"] // what this key can do
+  );
+}
+
+export async function sign2(options: SignOptions | string, payload: string) {
+  const { secret, algorithm } =
+    typeof options === "object"
+      ? {
+          secret: options.secret,
+          algorithm: options.algorithm || Algorithm.SHA256,
+        }
+      : { secret: options, algorithm: Algorithm.SHA256 };
+
+  if (!secret || !payload) {
+    throw new TypeError(
+      "[@octokit/webhooks-methods] secret & payload required for sign()"
+    );
+  }
+
+  if (!Object.values(Algorithm).includes(algorithm as Algorithm)) {
+    throw new TypeError(
+      `[@octokit/webhooks] Algorithm ${algorithm} is not supported. Must be  'sha1' or 'sha256'`
+    );
+  }
+
+  return `${algorithm}=${await _sign(secret, payload, algorithm)}`;
+}
+
+export async function verify2(
+  secret: string,
+  eventPayload: string,
+  signature: string
+) {
+  if (!secret || !eventPayload || !signature) {
+    throw new TypeError(
+      "[@octokit/webhooks-methods] secret, eventPayload & signature required"
+    );
+  }
+
+  const algorithm = getAlgorithm(signature);
+  return await _verify(
+    secret,
+    eventPayload,
+    signature.replace(`${algorithm}=`, ""),
+    algorithm
   );
 }

--- a/test/browser-test.js
+++ b/test/browser-test.js
@@ -12,7 +12,7 @@ async function runTests() {
   await page.goto("file:///");
 
   await page.addScriptTag({
-    content: script.replace("export { sign, sign2, verify, verify2 };", ""),
+    content: script.replace("export { sign, verify };", ""),
   });
 
   const [signature, verified] = await page.evaluate(async function () {
@@ -27,25 +27,9 @@ async function runTests() {
 
   strictEqual(
     signature,
-    "1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db"
-  );
-  strictEqual(verified, true);
-
-  const [signature2, verified2] = await page.evaluate(async function () {
-    const signature = await sign2("secret", "data");
-    console.log(signature);
-
-    const verified = await verify2("secret", "data", signature);
-    console.log(verified);
-
-    return [signature, verified];
-  });
-
-  strictEqual(
-    signature2,
     "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db"
   );
-  strictEqual(verified2, true);
+  strictEqual(verified, true);
 
   await browser.close();
 

--- a/test/browser-test.js
+++ b/test/browser-test.js
@@ -12,7 +12,7 @@ async function runTests() {
   await page.goto("file:///");
 
   await page.addScriptTag({
-    content: script.replace("export { sign, verify };", ""),
+    content: script.replace("export { sign, sign2, verify, verify2 };", ""),
   });
 
   const [signature, verified] = await page.evaluate(async function () {
@@ -30,6 +30,22 @@ async function runTests() {
     "1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db"
   );
   strictEqual(verified, true);
+
+  const [signature2, verified2] = await page.evaluate(async function () {
+    const signature = await sign2("secret", "data");
+    console.log(signature);
+
+    const verified = await verify2("secret", "data", signature);
+    console.log(verified);
+
+    return [signature, verified];
+  });
+
+  strictEqual(
+    signature2,
+    "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db"
+  );
+  strictEqual(verified2, true);
 
   await browser.close();
 

--- a/test/deno/web.test.ts
+++ b/test/deno/web.test.ts
@@ -1,3 +1,5 @@
+// we currently no support deno yet.
+
 import { sign, verify } from "../../src/web.ts";
 
 import { assertEquals } from "std/testing/asserts.ts";

--- a/test/deno/web.test.ts
+++ b/test/deno/web.test.ts
@@ -1,4 +1,4 @@
-import { sign, verify } from "../../src/web.ts";
+import { sign, verify } from "../../pkg/dist-web/index.js";
 
 import { assertEquals } from "std/testing/asserts.ts";
 

--- a/test/deno/web.test.ts
+++ b/test/deno/web.test.ts
@@ -1,5 +1,3 @@
-// we currently no support deno yet.
-
 import { sign, verify } from "../../src/web.ts";
 
 import { assertEquals } from "std/testing/asserts.ts";

--- a/test/deno/web.test.ts
+++ b/test/deno/web.test.ts
@@ -5,13 +5,13 @@ import { assertEquals } from "std/testing/asserts.ts";
 Deno.test("sign", async () => {
   const actual = await sign("secret", "data");
   const expected =
-    "1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
+    "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
   assertEquals(actual, expected);
 });
 
 Deno.test("verify", async () => {
   const signature =
-    "1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
+    "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
   const actual = await verify("secret", "data", signature);
   const expected = true;
   assertEquals(actual, expected);


### PR DESCRIPTION
I'm using the [`@octokit/webhooks`](https://github.com/octokit/webhooks.js#webhooksreceive) package in [cloudflare workers](https://workers.dev), and I found the verify and sign are imcompatible with the document: 
<img width="766" alt="image" src="https://user-images.githubusercontent.com/13938334/152761878-8f18d4e0-b488-4f6a-9332-b7223989204b.png">

but when I pass this para to `verify` func, it just said the signature are not valid.

then I notice that the event's signature has a prefix: `sha256=`
<img width="541" alt="image" src="https://user-images.githubusercontent.com/13938334/152762100-e7372b38-01d3-4ab0-8657-ba862029d328.png">

because the verify func in browser just return the hash. so it's clearly that:

```js
> "sha256=12345" !== "12345"
true
```

and when I see the node version code logic, I found it did some processes on signature string. so I do the same on the web version.

For compatibility, I just create a new function named `verify2` and `sign2`, and I want one day we can remove the old `verify` and `sign` function as a breaking change.