### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ["12", "14", "16"]
+        node_version:
+          - 14
+          - 16
+          - 18
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3

--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
         "@pika/plugin-ts-standard-pkg"
       ],
       [
-        "@pika/plugin-build-node"
+        "@pika/plugin-build-node",
+        {
+          "minNodeVersion": "14"
+        }
       ],
       [
         "@gr2m/pika-plugin-build-web"
@@ -105,5 +108,8 @@
     "extends": [
       "github>octokit/.github"
     ]
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12