### PR TITLE
Remove pika and add tsconfig.test.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "devDependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@pika/plugin-ts-standard-pkg": "^0.9.2",
+        "@octokit/tsconfig": "^2.0.0",
         "@types/jest": "^29.0.0",
         "@types/node": "^18.0.0",
         "esbuild": "^0.17.19",
@@ -106,18 +105,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.21.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
@@ -152,29 +139,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz",
-      "integrity": "sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-environment-visitor": "^7.21.5",
-        "@babel/helper-function-name": "^7.21.0",
-        "@babel/helper-member-expression-to-functions": "^7.21.5",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.21.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.21.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
@@ -204,18 +168,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.5.tgz",
-      "integrity": "sha512-nIcGfgwpH2u4n9GG1HpStW5Ogx7x7ekiFHbjjFRKXbn5zUvqO9ZgotCO4x1aNbKn/x/xOUaXEhyNHCwtFCpxWg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -252,40 +204,11 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.21.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
       "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.21.5.tgz",
-      "integrity": "sha512-/y7vBgsr9Idu4M6MprbOVUfH3vs7tsIfnVWv/Ml2xgwvyH6LTngdfbf5AdsKwkJy4zgy1X/kuNrEKvhhK28Yrg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.21.5",
-        "@babel/helper-member-expression-to-functions": "^7.21.5",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -297,18 +220,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.21.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
-      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.20.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -424,18 +335,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -574,60 +473,6 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz",
-      "integrity": "sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helper-plugin-utils": "^7.21.5",
-        "@babel/helper-simple-access": "^7.21.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.21.3.tgz",
-      "integrity": "sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-typescript": "^7.20.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/preset-typescript": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.21.5.tgz",
-      "integrity": "sha512-iqe3sETat5EOrORXiQ6rWfoOg2y68Cs75B9wNxdPW4kixJxh7aXQE1KPdWLDniC24T/6dSnguF33W9j/ZZQcmA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.21.5",
-        "@babel/helper-validator-option": "^7.21.0",
-        "@babel/plugin-syntax-jsx": "^7.21.4",
-        "@babel/plugin-transform-modules-commonjs": "^7.21.5",
-        "@babel/plugin-transform-typescript": "^7.21.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2143,9 +1988,9 @@
       }
     },
     "node_modules/@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
       "dev": true
     },
     "node_modules/@octokit/types": {
@@ -2156,29 +2001,6 @@
       "dependencies": {
         "@octokit/openapi-types": "^17.1.1"
       }
-    },
-    "node_modules/@pika/babel-plugin-esm-import-rewrite": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@pika/babel-plugin-esm-import-rewrite/-/babel-plugin-esm-import-rewrite-0.6.1.tgz",
-      "integrity": "sha512-B6CMCfc8EZT/0WUqPZJWf7LCXbqq4R41F5Xbifcy0HaMDxScoEW1zFPrYQLUs9+8B365JnKq3n+U6kMkFYT45w==",
-      "dev": true
-    },
-    "node_modules/@pika/plugin-ts-standard-pkg": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@pika/plugin-ts-standard-pkg/-/plugin-ts-standard-pkg-0.9.2.tgz",
-      "integrity": "sha512-LwObacitvuILyXzdmbB1gyGtPjERxSF83omBHfoagsSUqgIf4FZDo9Z3v5VpI7Sq7mtIjQ7D3cjKv8r7JyyY5Q==",
-      "dev": true,
-      "dependencies": {
-        "@pika/types": "^0.9.2",
-        "execa": "^2.0.0",
-        "standard-pkg": "^0.5.0"
-      }
-    },
-    "node_modules/@pika/plugin-ts-standard-pkg/node_modules/@pika/types": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@pika/types/-/types-0.9.2.tgz",
-      "integrity": "sha512-AzZTkHtM0A67+xMVhmSeJDteSMS+RfXGuM+/oVbo1PGD19ic7fuimv5b0TW8dKoZuxpVxiwVAai+sFRSNmfI3g==",
-      "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -4765,26 +4587,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/execa": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^3.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.12.0 || >=9.7.0"
       }
     },
     "node_modules/exit": {
@@ -7875,18 +7677,6 @@
       "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
       "dev": true
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -8150,18 +7940,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/@colors/colors": {
@@ -11361,15 +11139,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -12962,49 +12731,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/standard-pkg": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/standard-pkg/-/standard-pkg-0.5.0.tgz",
-      "integrity": "sha512-7w+8qU4hBMXeh5GmUTG39ODsqdaWrNZ8nq1gpPZu990DjuGVY6eCAhrcY+zFGc5OWlANqlF0XVArSU38J3HUUQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.2.2",
-        "@babel/parser": "^7.1.5",
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-        "@babel/plugin-syntax-import-meta": "^7.2.0",
-        "@babel/preset-typescript": "^7.1.0",
-        "@babel/traverse": "^7.1.5",
-        "@pika/babel-plugin-esm-import-rewrite": "^0.6.1",
-        "@types/minimist": "^1.2.0",
-        "chalk": "^2.1.0",
-        "glob": "^7.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1"
-      },
-      "bin": {
-        "standard-pkg": "dist-node/index.bin.js"
-      }
-    },
-    "node_modules/standard-pkg/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -14006,15 +13732,6 @@
         "jsesc": "^2.5.1"
       }
     },
-    "@babel/helper-annotate-as-pure": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.18.6"
-      }
-    },
     "@babel/helper-compilation-targets": {
       "version": "7.21.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
@@ -14045,23 +13762,6 @@
         }
       }
     },
-    "@babel/helper-create-class-features-plugin": {
-      "version": "7.21.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.8.tgz",
-      "integrity": "sha512-+THiN8MqiH2AczyuZrnrKL6cAxFRRQDKW9h1YkBvbgKmAm6mwiacig1qT73DHIWMGo40GRnsEfN3LA+E6NtmSw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-environment-visitor": "^7.21.5",
-        "@babel/helper-function-name": "^7.21.0",
-        "@babel/helper-member-expression-to-functions": "^7.21.5",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.21.5",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "semver": "^6.3.0"
-      }
-    },
     "@babel/helper-environment-visitor": {
       "version": "7.21.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
@@ -14085,15 +13785,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.21.5.tgz",
-      "integrity": "sha512-nIcGfgwpH2u4n9GG1HpStW5Ogx7x7ekiFHbjjFRKXbn5zUvqO9ZgotCO4x1aNbKn/x/xOUaXEhyNHCwtFCpxWg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.21.5"
       }
     },
     "@babel/helper-module-imports": {
@@ -14121,34 +13812,11 @@
         "@babel/types": "^7.21.5"
       }
     },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.18.6"
-      }
-    },
     "@babel/helper-plugin-utils": {
       "version": "7.21.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
       "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
       "dev": true
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.21.5.tgz",
-      "integrity": "sha512-/y7vBgsr9Idu4M6MprbOVUfH3vs7tsIfnVWv/Ml2xgwvyH6LTngdfbf5AdsKwkJy4zgy1X/kuNrEKvhhK28Yrg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-environment-visitor": "^7.21.5",
-        "@babel/helper-member-expression-to-functions": "^7.21.5",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.5",
-        "@babel/types": "^7.21.5"
-      }
     },
     "@babel/helper-simple-access": {
       "version": "7.21.5",
@@ -14157,15 +13825,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.21.5"
-      }
-    },
-    "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
-      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.20.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -14248,15 +13907,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.12.13"
-      }
-    },
-    "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
     "@babel/plugin-syntax-import-meta": {
@@ -14356,42 +14006,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.20.2"
-      }
-    },
-    "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz",
-      "integrity": "sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-transforms": "^7.21.5",
-        "@babel/helper-plugin-utils": "^7.21.5",
-        "@babel/helper-simple-access": "^7.21.5"
-      }
-    },
-    "@babel/plugin-transform-typescript": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.21.3.tgz",
-      "integrity": "sha512-RQxPz6Iqt8T0uw/WsJNReuBpWpBqs/n7mNo18sKLoTbMp+UrEekhH+pKSVC7gWz+DNjo9gryfV8YzCiT45RgMw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-typescript": "^7.20.0"
-      }
-    },
-    "@babel/preset-typescript": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.21.5.tgz",
-      "integrity": "sha512-iqe3sETat5EOrORXiQ6rWfoOg2y68Cs75B9wNxdPW4kixJxh7aXQE1KPdWLDniC24T/6dSnguF33W9j/ZZQcmA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.21.5",
-        "@babel/helper-validator-option": "^7.21.0",
-        "@babel/plugin-syntax-jsx": "^7.21.4",
-        "@babel/plugin-transform-modules-commonjs": "^7.21.5",
-        "@babel/plugin-transform-typescript": "^7.21.3"
       }
     },
     "@babel/template": {
@@ -15430,9 +15044,9 @@
       }
     },
     "@octokit/tsconfig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
+      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
       "dev": true
     },
     "@octokit/types": {
@@ -15442,31 +15056,6 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^17.1.1"
-      }
-    },
-    "@pika/babel-plugin-esm-import-rewrite": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@pika/babel-plugin-esm-import-rewrite/-/babel-plugin-esm-import-rewrite-0.6.1.tgz",
-      "integrity": "sha512-B6CMCfc8EZT/0WUqPZJWf7LCXbqq4R41F5Xbifcy0HaMDxScoEW1zFPrYQLUs9+8B365JnKq3n+U6kMkFYT45w==",
-      "dev": true
-    },
-    "@pika/plugin-ts-standard-pkg": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@pika/plugin-ts-standard-pkg/-/plugin-ts-standard-pkg-0.9.2.tgz",
-      "integrity": "sha512-LwObacitvuILyXzdmbB1gyGtPjERxSF83omBHfoagsSUqgIf4FZDo9Z3v5VpI7Sq7mtIjQ7D3cjKv8r7JyyY5Q==",
-      "dev": true,
-      "requires": {
-        "@pika/types": "^0.9.2",
-        "execa": "^2.0.0",
-        "standard-pkg": "^0.5.0"
-      },
-      "dependencies": {
-        "@pika/types": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/@pika/types/-/types-0.9.2.tgz",
-          "integrity": "sha512-AzZTkHtM0A67+xMVhmSeJDteSMS+RfXGuM+/oVbo1PGD19ic7fuimv5b0TW8dKoZuxpVxiwVAai+sFRSNmfI3g==",
-          "dev": true
-        }
       }
     },
     "@pkgjs/parseargs": {
@@ -17359,23 +16948,6 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
-    },
-    "execa": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-      "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^3.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      }
     },
     "exit": {
       "version": "0.1.2",
@@ -19657,15 +19229,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
       "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.6"
-      }
     },
     "mkdirp-classic": {
       "version": "0.5.3",
@@ -21989,15 +21552,6 @@
         }
       }
     },
-    "npm-run-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-      "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.0.0"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -22030,12 +21584,6 @@
       "requires": {
         "p-map": "^2.0.0"
       }
-    },
-    "p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -23159,42 +22707,6 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
-        }
-      }
-    },
-    "standard-pkg": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/standard-pkg/-/standard-pkg-0.5.0.tgz",
-      "integrity": "sha512-7w+8qU4hBMXeh5GmUTG39ODsqdaWrNZ8nq1gpPZu990DjuGVY6eCAhrcY+zFGc5OWlANqlF0XVArSU38J3HUUQ==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.2.2",
-        "@babel/parser": "^7.1.5",
-        "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-        "@babel/plugin-syntax-import-meta": "^7.2.0",
-        "@babel/preset-typescript": "^7.1.0",
-        "@babel/traverse": "^7.1.5",
-        "@pika/babel-plugin-esm-import-rewrite": "^0.6.1",
-        "@types/minimist": "^1.2.0",
-        "chalk": "^2.1.0",
-        "glob": "^7.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "typescript": "^5.0.0"
   },
   "jest": {
-    "preset": "ts-jest",
     "transform": {
       "^.+\\.(ts|tsx)$": [
         "ts-jest",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "author": "Gregor Martynus (https://dev.to/gr2m)",
   "license": "MIT",
   "devDependencies": {
-    "@octokit/tsconfig": "^1.0.2",
-    "@pika/plugin-ts-standard-pkg": "^0.9.2",
+    "@octokit/tsconfig": "^2.0.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.0.0",
     "esbuild": "^0.17.19",
@@ -43,6 +42,14 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "transform": {
+      "^.+\\.(ts|tsx)$": [
+        "ts-jest",
+        {
+          "tsconfig": "test/tsconfig.test.json"
+        }
+      ]
+    },
     "coverageThreshold": {
       "global": {
         "statements": 100,

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "outDir": "pkg/dist-types",
     "emitDeclarationOnly": true,
-    "sourceMap": true,
+    "sourceMap": true
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "outDir": "pkg/dist-types",
     "emitDeclarationOnly": true,
-    "sourceMap": true
+    "sourceMap": true,
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR uses [auth-token.js#345](https://github.com/octokit/auth-token.js/pull/345) as a model to update the major octokit/tsconfig version and adds a test-specific tsconfig. 

It also removes the last (unused) pika package in this repo. 