### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [Methods](#methods)
   - [`sign()`](#sign)
   - [`verify()`](#verify)
-  - [`verifyWithFallback()`](#verifyWithFallback)
+  - [`verifyWithFallback()`](#verifywithfallback)
 - [Contributing](#contributing)
 - [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Browsers
 
 🚧 `@octokit/webhooks-methods` is not meant to be used in browsers. The webhook secret is a sensitive credential that must not be exposed to users.
 
-Load `@octokit/webhooks-methods` directly from [cdn.skypack.dev](https://cdn.skypack.dev)
+Load `@octokit/webhooks-methods` directly from [esm.sh](https://esm.sh)
 
 ```html
 <script type="module">
@@ -42,7 +42,7 @@ Load `@octokit/webhooks-methods` directly from [cdn.skypack.dev](https://cdn.sky
     sign,
     verify,
     verifyWithFallback,
-  } from "https://cdn.skypack.dev/@octokit/webhooks-methods";
+  } from "https://esm.sh/@octokit/webhooks-methods";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.