### PR TITLE
refactor: use `node:` specifier imports and full relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,11 @@
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/test/deno/"
-    ]
+    ],
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
+    }
   },
   "release": {
     "branches": [

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,5 +1,5 @@
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 const sharedOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { sign } from "./node/sign";
-import { verify } from "./node/verify";
+export { sign } from "./node/sign.js";
+import { verify } from "./node/verify.js";
 export { verify };
 
 export async function verifyWithFallback(

--- a/src/node/sign.ts
+++ b/src/node/sign.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "crypto";
+import { createHmac } from "node:crypto";
 import { Algorithm, type SignOptions } from "../types";
 import { VERSION } from "../version";
 

--- a/src/node/sign.ts
+++ b/src/node/sign.ts
@@ -1,6 +1,6 @@
 import { createHmac } from "node:crypto";
-import { Algorithm, type SignOptions } from "../types";
-import { VERSION } from "../version";
+import { Algorithm, type SignOptions } from "../types.js";
+import { VERSION } from "../version.js";
 
 export async function sign(
   options: SignOptions | string,

--- a/src/node/verify.ts
+++ b/src/node/verify.ts
@@ -1,9 +1,9 @@
 import { timingSafeEqual } from "node:crypto";
 import { Buffer } from "node:buffer";
 
-import { sign } from "./sign";
-import { VERSION } from "../version";
-import { getAlgorithm } from "../utils";
+import { sign } from "./sign.js";
+import { VERSION } from "../version.js";
+import { getAlgorithm } from "../utils.js";
 
 export async function verify(
   secret: string,

--- a/src/node/verify.ts
+++ b/src/node/verify.ts
@@ -1,5 +1,5 @@
-import { timingSafeEqual } from "crypto";
-import { Buffer } from "buffer";
+import { timingSafeEqual } from "node:crypto";
+import { Buffer } from "node:buffer";
 
 import { sign } from "./sign";
 import { VERSION } from "../version";

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,5 +1,5 @@
-import { Algorithm, type AlgorithmLike, type SignOptions } from "./types";
-import { getAlgorithm } from "./utils";
+import { Algorithm, type AlgorithmLike, type SignOptions } from "./types.js";
+import { getAlgorithm } from "./utils.js";
 
 const enc = new TextEncoder();
 

--- a/test/browser-test.js
+++ b/test/browser-test.js
@@ -1,6 +1,6 @@
-const { strictEqual } = require("assert");
+const { strictEqual } = require("node:assert");
 
-const { readFile } = require("fs").promises;
+const { readFile } = require("node:fs/promises");
 const puppeteer = require("puppeteer");
 
 runTests();

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -1,4 +1,4 @@
-import { sign } from "../src";
+import { sign } from "../src/index.ts";
 
 const eventPayload = {
   foo: "bar",

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -1,4 +1,4 @@
-import { verify, verifyWithFallback } from "../src";
+import { verify, verifyWithFallback } from "../src/index.ts";
 
 function toNormalizedJsonString(payload: object) {
   // GitHub sends its JSON with an indentation of 2 spaces and a line break at the end


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.