### PR TITLE
feat: throw an error when passing an `object` payload to `verify` or `sign`

### DIFF
--- a/src/node/sign.ts
+++ b/src/node/sign.ts
@@ -20,6 +20,10 @@ export async function sign(
     );
   }
 
+  if (typeof payload !== "string") {
+    throw new TypeError("[@octokit/webhooks-methods] payload must be a string");
+  }
+
   if (!Object.values(Algorithm).includes(algorithm as Algorithm)) {
     throw new TypeError(
       `[@octokit/webhooks] Algorithm ${algorithm} is not supported. Must be  'sha1' or 'sha256'`,

--- a/src/node/verify.ts
+++ b/src/node/verify.ts
@@ -16,6 +16,12 @@ export async function verify(
     );
   }
 
+  if (typeof eventPayload !== "string") {
+    throw new TypeError(
+      "[@octokit/webhooks-methods] eventPayload must be a string",
+    );
+  }
+
   const signatureBuffer = Buffer.from(signature);
   const algorithm = getAlgorithm(signature);
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -60,6 +60,10 @@ export async function sign(options: SignOptions | string, payload: string) {
     );
   }
 
+  if (typeof payload !== "string") {
+    throw new TypeError("[@octokit/webhooks-methods] payload must be a string");
+  }
+
   if (!Object.values(Algorithm).includes(algorithm as Algorithm)) {
     throw new TypeError(
       `[@octokit/webhooks] Algorithm ${algorithm} is not supported. Must be  'sha1' or 'sha256'`,
@@ -83,6 +87,12 @@ export async function verify(
   if (!secret || !eventPayload || !signature) {
     throw new TypeError(
       "[@octokit/webhooks-methods] secret, eventPayload & signature required",
+    );
+  }
+
+  if (typeof eventPayload !== "string") {
+    throw new TypeError(
+      "[@octokit/webhooks-methods] eventPayload must be a string",
     );
   }
 

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -38,7 +38,7 @@ describe("sign", () => {
   test("sign({secret, algorithm}) throws with invalid algorithm", async () => {
     await expect(() =>
       // @ts-expect-error
-      sign({ secret, algorithm: "sha2" }, eventPayload),
+      sign({ secret, algorithm: "sha2" }, JSON.stringify(eventPayload)),
     ).rejects.toThrow(
       "[@octokit/webhooks] Algorithm sha2 is not supported. Must be  'sha1' or 'sha256'",
     );
@@ -80,5 +80,12 @@ describe("sign", () => {
         );
       });
     });
+  });
+
+  test("throws with eventPayload as object", () => {
+    // @ts-expect-error
+    expect(() => sign(secret, eventPayload)).rejects.toThrow(
+      "[@octokit/webhooks-methods] payload must be a string",
+    );
   });
 });

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -8,7 +8,8 @@ function toNormalizedJsonString(payload: object) {
   });
 }
 
-const eventPayload = toNormalizedJsonString({ foo: "bar" });
+const JSONeventPayload = { foo: "bar" };
+const eventPayload = toNormalizedJsonString(JSONeventPayload);
 const secret = "mysecret";
 const signatureSHA1 = "sha1=640c0ea7402a3f74e1767338fa2dba243b1f2d9c";
 const signatureSHA256 =
@@ -139,6 +140,15 @@ describe("verify", () => {
       "sha256=87316067e2011fae39998b18c46a14d83b3e7c3ffdd88fb2ee5afb7d11288e60",
     );
     expect(signatureMatchesEscapedSequence).toBe(true);
+  });
+
+  test("verify(secret, eventPayload, signatureSHA256) with JSON eventPayload", async () => {
+    await expect(() =>
+      // @ts-expect-error
+      verify(secret, JSONeventPayload, signatureSHA256),
+    ).rejects.toThrow(
+      "[@octokit/webhooks-methods] eventPayload must be a string",
+    );
   });
 });
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/probot/probot/issues/1974
See https://github.com/octokit/webhooks.js/issues/961#issuecomment-1937116804

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Silently accepts payload objects when users aren't using TypeScript

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Throws an error whenever an `object` payload is passsed

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

