### PR TITLE
chore: unpin node 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         node_version:
           - 18
           - 20
-          - '22.4.1'
+          - 22
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Use Node.js ${{ matrix.node_version }}


### PR DESCRIPTION
This PR will unpin node 22.5.0 and should be applied if a newer node version is applied.