### PR TITLE
fix: add `verifyWithFallback()` function in the web entrpoint

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -79,3 +79,26 @@ export async function verify(
     enc.encode(eventPayload),
   );
 }
+export async function verifyWithFallback(
+  secret: string,
+  payload: string,
+  signature: string,
+  additionalSecrets: undefined | string[],
+): Promise<any> {
+  const firstPass = await verify(secret, payload, signature);
+
+  if (firstPass) {
+    return true;
+  }
+
+  if (additionalSecrets !== undefined) {
+    for (const s of additionalSecrets) {
+      const v: boolean = await verify(s, payload, signature);
+      if (v) {
+        return v;
+      }
+    }
+  }
+
+  return false;
+}

--- a/test/deno/web_test.ts
+++ b/test/deno/web_test.ts
@@ -20,9 +20,7 @@ Deno.test("verify", async () => {
 Deno.test("verify with fallback", async () => {
   const signature =
     "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
-  const actual = await verifyWithFallback("foo", "data", signature, [
-    "secret",
-  ]);
+  const actual = await verifyWithFallback("foo", "data", signature, ["secret"]);
   const expected = true;
   assertEquals(actual, expected);
 });

--- a/test/deno/web_test.ts
+++ b/test/deno/web_test.ts
@@ -21,7 +21,7 @@ Deno.test("verify with fallback", async () => {
   const signature =
     "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
   const actual = await verifyWithFallback("foo", "data", signature, [
-    "mysecret",
+    "secret",
   ]);
   const expected = true;
   assertEquals(actual, expected);

--- a/test/deno/web_test.ts
+++ b/test/deno/web_test.ts
@@ -1,4 +1,4 @@
-import { sign, verify } from "../../pkg/dist-web/index.js";
+import { sign, verify, verifyWithFallback } from "../../pkg/dist-web/index.js";
 
 import { assertEquals } from "@std/assert";
 
@@ -13,6 +13,19 @@ Deno.test("verify", async () => {
   const signature =
     "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
   const actual = await verify("secret", "data", signature);
+  const expected = true;
+  assertEquals(actual, expected);
+});
+
+Deno.test("verify with fallback", async () => {
+  const signature =
+    "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
+  const actual = await verifyWithFallback(
+    "foo",
+    "data",
+    signature,
+    ["mysecret"],
+  );
   const expected = true;
   assertEquals(actual, expected);
 });

--- a/test/deno/web_test.ts
+++ b/test/deno/web_test.ts
@@ -20,12 +20,9 @@ Deno.test("verify", async () => {
 Deno.test("verify with fallback", async () => {
   const signature =
     "sha256=1b2c16b75bd2a870c114153ccda5bcfca63314bc722fa160d690de133ccbb9db";
-  const actual = await verifyWithFallback(
-    "foo",
-    "data",
-    signature,
-    ["mysecret"],
-  );
+  const actual = await verifyWithFallback("foo", "data", signature, [
+    "mysecret",
+  ]);
   const expected = true;
   assertEquals(actual, expected);
 });


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
See https://github.com/octokit/webhooks.js/issues/1099

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `verifyWithFallback()` function was added in #134 but was only added for Node

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds the `verifyWithFallback()` function to the web entrypoint

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

