### PR TITLE
test: fix unhandled promise rejection

### DIFF
--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -47,9 +47,9 @@ describe("sign", () => {
     });
   });
 
-  it("throws with eventPayload as object", () => {
+  it("throws with eventPayload as object", async () => {
     // @ts-expect-error
-    expect(() => sign(secret, eventPayload)).rejects.toThrow(
+    await expect(() => sign(secret, eventPayload)).rejects.toThrow(
       "[@octokit/webhooks-methods] payload must be a string",
     );
   });


### PR DESCRIPTION
fixes following 

```sh
stderr | test/sign.test.ts > sign > throws with eventPayload as object
Promise returned by `expect(actual).rejects.toThrow(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
    at /home/aras/workspace/webhooks-methods.js/test/sign.test.ts:52:44

```