### PR TITLE
[webhooks-methods] add defaults to exports

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -67,14 +67,17 @@ async function main() {
             node: {
               types: "./dist-types/index.d.ts",
               import: "./dist-node/index.js",
+              default: "./dist-node/index.js",
             },
             browser: {
               types: "./dist-types/web.d.ts",
               import: "./dist-web/index.js",
+              default: "./dist-web/index.js",
             },
             default: {
               types: "./dist-types/index.d.ts",
               import: "./dist-node/index.js",
+              default: "./dist-node/index.js",
             },
           },
         },


### PR DESCRIPTION
Resolves https://github.com/octokit/core.js/issues/667
Resolves https://github.com/octokit/core.js/issues/665
Partly reverts https://github.com/octokit/core.js/pull/662

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Some consumers of this package could not resolve it properly (ex: jest, ts-node, tsx)
* CJS consumers would be getting errors even though the package is ESM
* Consumers cannot import paths from the package like in CJS

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Clients should be able to import the module without any errors with the fallback
* CJS consumers will generate a better error with the new fallback

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

